### PR TITLE
Use TraceLogging for printk

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1548,6 +1548,11 @@ ebpf_native_load_programs(
     bool maps_created = false;
     bool cleanup_context_created = false;
 
+    if ((count_of_map_handles > 0 && map_handles == NULL) ||
+        (count_of_program_handles > 0 && program_handles == NULL)) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
     // Find the native entry in hash table.
     state = ebpf_lock_lock(&_ebpf_native_client_table_lock);
     lock_acquired = true;

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -487,29 +487,6 @@ Done:
     return result;
 }
 
-// Pick an arbitrary limit on string size roughly based on the size of the eBPF stack.
-// This is enough space for a format string that takes up all the eBPF stack space,
-// plus room to expand three 64-bit integer arguments from 2-character format specifiers.
-#define MAX_PRINTK_STRING_SIZE 554
-
-long
-ebpf_platform_printk(_In_z_ const char* format, va_list arg_list)
-{
-    char* output = (char*)ebpf_allocate(MAX_PRINTK_STRING_SIZE);
-    if (output == NULL) {
-        return -1;
-    }
-
-    long bytes_written = -1;
-    if (RtlStringCchVPrintfA(output, MAX_PRINTK_STRING_SIZE, format, arg_list) == 0) {
-        EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_PRINTK, output);
-        bytes_written = (long)strlen(output);
-    }
-
-    ebpf_free(output);
-    return bytes_written;
-}
-
 _Must_inspect_result_ ebpf_result_t
 ebpf_update_global_helpers(
     _In_reads_(helper_info_count) ebpf_helper_function_prototype_t* helper_info, uint32_t helper_info_count)

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -423,7 +423,9 @@ Exit:
 static void
 _net_ebpf_extension_hook_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context)
 {
-    ExFreePool(provider_binding_context);
+    if (provider_binding_context != NULL) {
+        ExFreePool(provider_binding_context);
+    }
 }
 
 void

--- a/tests/libs/util/capture_helper.cpp
+++ b/tests/libs/util/capture_helper.cpp
@@ -33,6 +33,25 @@ capture_helper_t::get_stderr_contents(void)
     return _stderr_contents;
 }
 
+std::vector<std::string>
+capture_helper_t::buffer_to_printk_vector(std::string buffer)
+{
+    // Given a string, return a vector of strings, splitting by line breaks.
+    std::istringstream ss(buffer);
+    std::vector<std::string> result;
+    const std::string printk_prefix = "{EbpfGenericMessage,\"";
+    const std::string printk_suffix = "\",\"Message\"}";
+    for (std::string line; std::getline(ss, line, '\n');) {
+        if (line.starts_with(printk_prefix) && line.ends_with(printk_suffix)) {
+            // See if the string fits the pattern:
+            // {EbpfGenericMessage,"<some string>","Message"}
+            result.push_back(
+                line.substr(printk_prefix.length(), line.length() - printk_prefix.length() - printk_suffix.length()));
+        }
+    }
+    return result;
+}
+
 _Success_(return == 0) errno_t capture_helper_t::begin_fd_capture(
     _In_ FILE* fp, _Out_ int* original_fd, _In_z_ const char* temporary_filename)
 {

--- a/tests/libs/util/capture_helper.hpp
+++ b/tests/libs/util/capture_helper.hpp
@@ -6,6 +6,7 @@
 #include <sal.h>
 #include <stdio.h>
 #include <string>
+#include <vector>
 
 class capture_helper_t final
 {
@@ -30,4 +31,6 @@ class capture_helper_t final
     get_stdout_contents(void);
     std::string
     get_stderr_contents(void);
+    static std::vector<std::string>
+    buffer_to_printk_vector(std::string buffer);
 };

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -34,6 +34,7 @@ _native_module_helper::initialize(_In_z_ const char* file_name_prefix, ebpf_exec
         _file_name =
             file_name_prefix_string + std::string(guid_string) + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
         REQUIRE(CopyFileA(original_file_name.c_str(), _file_name.c_str(), TRUE) == TRUE);
+        RpcStringFreeA((RPC_CSTR*)guid_string);
     } else {
         _file_name = std::string(file_name_prefix) + std::string(EBPF_PROGRAM_FILE_EXTENSION_JIT);
     }

--- a/tests/stress/km/ebpf_stress_tests_km.vcxproj
+++ b/tests/stress/km/ebpf_stress_tests_km.vcxproj
@@ -151,7 +151,12 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\libs\platform\ebpf_tracelog.c" />
+    <ClCompile Include="..\..\..\libs\platform\ebpf_tracelog.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NO_TRACE_LOGGING_OVERRIDE;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='NativeOnlyDebug|x64'">NO_TRACE_LOGGING_OVERRIDE;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='NativeOnlyRelease|x64'">NO_TRACE_LOGGING_OVERRIDE;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NO_TRACE_LOGGING_OVERRIDE;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\ebpf_stress_tests.cpp" />
     <ClCompile Include="stress_tests_km.cpp" />
   </ItemGroup>


### PR DESCRIPTION
In kernel mode, trace logging and printk share the same channel.  This PR makes the usersim environment do the same thing, for higher fidelity testing.

This also fixes 2 bugs found by doing such testing:
* Fix bug in _net_ebpf_extension_hook_provider_cleanup_binding_context()
* Fix leak in _native_module_helper::initialize()